### PR TITLE
removed autorev from swupdate bbappend, which leads to build always t…

### DIFF
--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -8,8 +8,6 @@ SRC_URI += " \
      file://swupdate.cfg \
      "
 
-SRCREV = "${AUTOREV}"
-
 do_install_append() {
     install -d ${D}${bindir}
     install -m 755 ${S}/progress ${D}${bindir}


### PR DESCRIPTION
because of the manipulation of srcrev, it doesnt matter which version is preferred, it will take always the master HEAD