### PR TITLE
bootargs value must be quoted to be a valid setenv command

### DIFF
--- a/dynamic-layers/raspberrypi/recipes-bsp/rpi-uboot-scr/files/boot.cmd.in
+++ b/dynamic-layers/raspberrypi/recipes-bsp/rpi-uboot-scr/files/boot.cmd.in
@@ -2,5 +2,5 @@ saveenv
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 if env exists rpipart;then echo Booting from mmcblk0p${rpipart};else setenv rpipart 2;echo rpipart not set, default to ${rpipart};fi
 load mmc 0:${rpipart} ${kernel_addr_r} boot/@@KERNEL_IMAGETYPE@@
-setenv bootargs ${bootargs} root=/dev/mmcblk0p${rpipart}
+setenv bootargs "${bootargs} root=/dev/mmcblk0p${rpipart}"
 @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}


### PR DESCRIPTION
Using the example provided here on a raspberry pi as-is, uboot does not switch the boot partition after updating correctly and instead prints the usage for `setenv` to the console:

```
U-Boot 2020.01 (Jan 06 2020 - 20:56:31 +0000)

DRAM:  3.9 GiB
RPI 4 Model B (0xc03111)
MMC:   mmcnr@7e300000: 1, emmc2@7e340000: 0
Loading Environment from FAT... OK
In:    serial
Out:   serial
Err:   serial
Net:   Net Initialization Skipped
No ethernet found.
Hit any key to stop autoboot:  0
switch to partitions #0, OK
mmc0 is current device
Scanning mmc 0:1...
Found U-Boot script /boot.scr
422 bytes read in 9 ms (44.9 KiB/s)
## Executing script at 02400000
Saving Environment to FAT... OK
Booting from mmcblk0p3
6457824 bytes read in 1152 ms (5.3 MiB/s)
setenv - set environment variables

Usage:
setenv setenv [-f] name value ...
    - [forcibly] set environment variable 'name' to 'value ...'
setenv [-f] name
    - [forcibly] delete environment variable 'name'
```

I found that this was fixed by quoting the value argument to `setenv`:

```sh
setenv bootargs "${bootargs} root=/dev/mmcblk0p${rpipart}"
```