### PR TITLE
Wait til after the upper partition is mounted before starting overlay

### DIFF
--- a/dynamic-layers/raspberrypi/recipes-core/overlayfs/files/overlays-etc-dirs.service
+++ b/dynamic-layers/raspberrypi/recipes-core/overlayfs/files/overlays-etc-dirs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Create volatile upper and work dir for /etc overlayfs
 DefaultDependencies=no
-After=systemd-remount-fs.service
+After=systemd-remount-fs.service media.mount
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
In my experience using this recipe on a raspberry pi, the [`/media` mount from `mmcblk0p4`](https://github.com/sbabic/meta-swupdate-boards/blob/76554e196b018c0b891e5c9da10c2b605c7e2b98/wic/ts-raspberrypi.wks) was mounted _after_ this one-shot service ran to establish the `/etc` overlay. Making that service depend on `media.mount` fixes that.