### PR TITLE
09-swupdate-args: adapt rootfs string comparison to 'swupdate -g'

### DIFF
--- a/recipes-support/swupdate/swupdate/beaglebone-yocto/09-swupdate-args
+++ b/recipes-support/swupdate/swupdate/beaglebone-yocto/09-swupdate-args
@@ -1,6 +1,6 @@
 rootfs=`swupdate -g`
 
-if [ $rootfs == '/dev/mmcblk1p2' ];then
+if [ $rootfs == 'mmcblk1p2' ];then
 	selection="-e stable,copy2"
 else
 	selection="-e stable,copy1"

--- a/recipes-support/swupdate/swupdate/raspberrypi3/09-swupdate-args
+++ b/recipes-support/swupdate/swupdate/raspberrypi3/09-swupdate-args
@@ -1,6 +1,6 @@
 rootfs=`swupdate -g`
 
-if [ $rootfs == '/dev/mmcblk0p2' ];then
+if [ $rootfs == 'mmcblk0p2' ];then
 	selection="-e stable,copy2"
 else
 	selection="-e stable,copy1"

--- a/recipes-support/swupdate/swupdate/sama5d27-som1-ek-sd/09-swupdate-args
+++ b/recipes-support/swupdate/swupdate/sama5d27-som1-ek-sd/09-swupdate-args
@@ -1,6 +1,6 @@
 rootfs=`swupdate -g`
 
-if [ $rootfs == '/dev/mmcblk0p2' ];then
+if [ $rootfs == 'mmcblk0p2' ];then
 	selection="-e stable,copy2"
 else
 	selection="-e stable,copy1"

--- a/recipes-support/swupdate/swupdate/wandboard/09-swupdate-args
+++ b/recipes-support/swupdate/swupdate/wandboard/09-swupdate-args
@@ -1,6 +1,6 @@
 rootfs=`swupdate -g`
 
-if [ $rootfs == '/dev/mmcblk2p1' ];then
+if [ $rootfs == 'mmcblk2p1' ];then
 	selection="-e stable,copy2"
 else
 	selection="-e stable,copy1"


### PR DESCRIPTION
f748430fc2d0183bcbad93e5754ea44a95191f36 changed how the rootfs partition string is obtained, but it returns different strings than the previous method (i.e. without the "/dev/" part).

Note: I only tested this on a Raspberry Pi 4 and assumed that it is the same on other platforms.