### PR TITLE
layer.conf configured for kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PRIORITY_swupdate-boards = "7"
 
 LAYERDEPENDS_swupdate-boards = "swupdate"
 
-LAYERSERIES_COMPAT_swupdate-boards = "honister"
+LAYERSERIES_COMPAT_swupdate = "dunfell kirkstone"
 
 BBFILES_DYNAMIC += " \
     atmel:${LAYERDIR}/dynamic-layers/atmel/*/*/*.bb \


### PR DESCRIPTION
Kirkstone branch supported honister, but not kirkstone. 